### PR TITLE
Issue 92

### DIFF
--- a/general/automated_plan_optimization.py
+++ b/general/automated_plan_optimization.py
@@ -106,7 +106,7 @@ def make_variable_grid_list(n_iterations, variable_dose_grid):
     dose grid change.
 
     :param  n_iterations - number of total iterations to be run, from 1 to n_iterations
-            variable_dose_grid - a four element list with an iteration number
+    :param  variable_dose_grid - a four element list with an iteration number
               at each iteration number a grid change should occur
 
     :returns change_grid  (list type)
@@ -187,7 +187,7 @@ def check_min_jaws(plan_opt, min_dim):
                 mlc_thin_high = 47
             else:
                 logging.debug('Machine type unsupported for this check')
-                jaw_change = false
+                jaw_change = False
                 return jaw_change
             # Search for the maximum leaf extend among all positions
             if b.ForBeam.HasValidSegments:

--- a/protocols/UW/UWBrainCNS.xml
+++ b/protocols/UW/UWBrainCNS.xml
@@ -764,8 +764,8 @@
         </goals>
     </order>
     <order>
-        <name>Whole Brain w/ Hippocampal Sparing</name>
-        <prefix>Brai_</prefix>
+        <name>Whole Brain w/ HA - 30 Gy[RTOG0933/CC001]</name>
+        <prefix>WBHA_</prefix>
         <prescription>
             <roi>
                 <name>PTV_p</name>
@@ -781,8 +781,22 @@
             <roi>
                 <name>PTV_p</name>
                 <type dir="ge">VX</type>
+                <volume units="%">90</volume>
+                <dose units="%" roi="PTV_p">100</dose>
+                <priority>2</priority>
+            </roi>
+            <roi>
+                <name>PTV_p</name>
+                <type dir="ge">VX</type>
                 <volume units="%">95</volume>
                 <dose units="%" roi="PTV_p">100</dose>
+                <priority>4</priority>
+            </roi>
+            <roi>
+                <name>PTV_p</name>
+                <type dir="le">DX</type>
+                <volume units="%">2</volume>
+                <dose units="Gy">40</dose>
                 <priority>2</priority>
             </roi>
             <roi>
@@ -790,6 +804,13 @@
                 <type dir="le">DX</type>
                 <volume units="%">2</volume>
                 <dose units="Gy">37.5</dose>
+                <priority>4</priority>
+            </roi>
+            <roi>
+                <name>PTV_p</name>
+                <type dir="ge">DX</type>
+                <volume units="%">98</volume>
+                <dose units="Gy">22.5</dose>
                 <priority>2</priority>
             </roi>
             <roi>
@@ -797,37 +818,234 @@
                 <type dir="ge">DX</type>
                 <volume units="%">98</volume>
                 <dose units="Gy">25</dose>
-                <priority>2</priority>
+                <priority>4</priority>
             </roi>
             <roi>
-                <name>Hippocampus</name>
+                <name>Hippocampus_L</name>
+                <type dir="le">DX</type>
+                <volume units="%">100</volume>
+                <dose units="Gy">10</dose>
+                <priority>1</priority>
+            </roi>
+            <roi>
+                <name>Hippocampus_L</name>
                 <type dir="le">DX</type>
                 <volume units="%">100</volume>
                 <dose units="Gy">9</dose>
                 <priority>3</priority>
             </roi>
             <roi>
-                <name>Hippocampus</name>
+                <name>Hippocampus_L</name>
+                <type>Max</type>
+                <dose units="Gy">17</dose>
+                <priority>1</priority>
+            </roi>
+            <roi>
+                <name>Hippocampus_L</name>
                 <type>Max</type>
                 <dose units="Gy">16</dose>
                 <priority>3</priority>
             </roi>
-			<roi>
+            <roi>
+                <name>Hippocampus_R</name>
+                <type dir="le">DX</type>
+                <volume units="%">100</volume>
+                <dose units="Gy">10</dose>
+                <priority>1</priority>
+            </roi>
+            <roi>
+                <name>Hippocampus_R</name>
+                <type dir="le">DX</type>
+                <volume units="%">100</volume>
+                <dose units="Gy">9</dose>
+                <priority>3</priority>
+            </roi>
+            <roi>
+                <name>Hippocampus_R</name>
+                <type>Max</type>
+                <dose units="Gy">17</dose>
+                <priority>1</priority>
+            </roi>
+            <roi>
+                <name>Hippocampus_R</name>
+                <type>Max</type>
+                <dose units="Gy">16</dose>
+                <priority>3</priority>
+            </roi>
+            <roi>
                 <name>OpticChiasm</name>
                 <type>Max</type>
                 <dose units="Gy">37.5</dose>
+                <priority>1</priority>
+            </roi>
+			<roi>
+                <name>OpticChiasm</name>
+                <type>Max</type>
+                <dose units="Gy">30</dose>
                 <priority>3</priority>
             </roi>
             <roi>
                 <name>OpticNrv_L</name>
                 <type>Max</type>
                 <dose units="Gy">37.5</dose>
+                <priority>1</priority>
+            </roi>
+            <roi>
+                <name>OpticNrv_L</name>
+                <type>Max</type>
+                <dose units="Gy">30</dose>
                 <priority>3</priority>
             </roi>
             <roi>
                 <name>OpticNrv_R</name>
                 <type>Max</type>
                 <dose units="Gy">37.5</dose>
+                <priority>1</priority>
+            </roi>
+            <roi>
+                <name>OpticNrv_R</name>
+                <type>Max</type>
+                <dose units="Gy">30</dose>
+                <priority>3</priority>
+            </roi>
+        </goals>
+    </order>
+    <order>
+        <name>Whole Brain w/ HA - 25 Gy[CC003]</name>
+        <prefix>WBHA_</prefix>
+        <prescription>
+            <roi>
+                <name>PTV_p</name>
+                <type>DX</type>
+                <volume units="%">95</volume>
+                <dose units="Gy" idl="100">25</dose>
+            </roi>
+            <fractions>10</fractions>
+            <imaging>Daily CBCT</imaging>
+            <technique modality="Photons" technique="Conformal" code="VMAT" machine="TrueBeam">VMAT</technique>
+        </prescription>
+        <goals>
+            <roi>
+                <name>PTV_p</name>
+                <type dir="ge">VX</type>
+                <volume units="%">90</volume>
+                <dose units="%" roi="PTV_p">100</dose>
+                <priority>2</priority>
+            </roi>
+            <roi>
+                <name>PTV_p</name>
+                <type dir="ge">VX</type>
+                <volume units="%">95</volume>
+                <dose units="%" roi="PTV_p">100</dose>
+                <priority>4</priority>
+            </roi>
+            <roi>
+                <name>PTV_p</name>
+                <type dir="le">DX</type>
+                <volume units="%">2</volume>
+                <dose units="Gy">33.3</dose>
+                <priority>2</priority>
+            </roi>
+            <roi>
+                <name>PTV_p</name>
+                <type dir="le">DX</type>
+                <volume units="%">2</volume>
+                <dose units="Gy">31.25</dose>
+                <priority>4</priority>
+            </roi>
+            <roi>
+                <name>PTV_p</name>
+                <type dir="ge">DX</type>
+                <volume units="%">98</volume>
+                <dose units="Gy">21</dose>
+                <priority>2</priority>
+            </roi>
+            <roi>
+                <name>Hippocampus_L</name>
+                <type dir="le">DX</type>
+                <volume units="%">100</volume>
+                <dose units="Gy">8.5</dose>
+                <priority>1</priority>
+            </roi>
+            <roi>
+                <name>Hippocampus_L</name>
+                <type dir="le">DX</type>
+                <volume units="%">100</volume>
+                <dose units="Gy">7.5</dose>
+                <priority>3</priority>
+            </roi>
+            <roi>
+                <name>Hippocampus_L</name>
+                <type>Max</type>
+                <dose units="Gy">15</dose>
+                <priority>1</priority>
+            </roi>
+            <roi>
+                <name>Hippocampus_L</name>
+                <type>Max</type>
+                <dose units="Gy">13.5</dose>
+                <priority>3</priority>
+            </roi>
+            <roi>
+                <name>Hippocampus_R</name>
+                <type dir="le">DX</type>
+                <volume units="%">100</volume>
+                <dose units="Gy">8.5</dose>
+                <priority>1</priority>
+            </roi>
+            <roi>
+                <name>Hippocampus_R</name>
+                <type dir="le">DX</type>
+                <volume units="%">100</volume>
+                <dose units="Gy">7.5</dose>
+                <priority>3</priority>
+            </roi>
+            <roi>
+                <name>Hippocampus_R</name>
+                <type>Max</type>
+                <dose units="Gy">15</dose>
+                <priority>1</priority>
+            </roi>
+            <roi>
+                <name>Hippocampus_R</name>
+                <type>Max</type>
+                <dose units="Gy">13.5</dose>
+                <priority>3</priority>
+            </roi>
+            <roi>
+                <name>OpticChiasm</name>
+                <type>Max</type>
+                <dose units="Gy">36</dose>
+                <priority>1</priority>
+            </roi>
+			<roi>
+                <name>OpticChiasm</name>
+                <type>Max</type>
+                <dose units="Gy">25</dose>
+                <priority>3</priority>
+            </roi>
+            <roi>
+                <name>OpticNrv_L</name>
+                <type>Max</type>
+                <dose units="Gy">36</dose>
+                <priority>1</priority>
+            </roi>
+            <roi>
+                <name>OpticNrv_L</name>
+                <type>Max</type>
+                <dose units="Gy">25</dose>
+                <priority>3</priority>
+            </roi>
+            <roi>
+                <name>OpticNrv_R</name>
+                <type>Max</type>
+                <dose units="Gy">36</dose>
+                <priority>1</priority>
+            </roi>
+            <roi>
+                <name>OpticNrv_R</name>
+                <type>Max</type>
+                <dose units="Gy">25</dose>
                 <priority>3</priority>
             </roi>
         </goals>


### PR DESCRIPTION
For Automated plan optimization, I corrected a bug that was preventing the auto-optimize script from being used with TomoTherapy machines.  This bug did not affect existing TomoTherapy plans.

I updated the Hippocampal sparing protocols to reflect CC003/CC001 limits.  Note that I have changed the automated protocol name to "WBHA_" from "Brai_".  Going forward, we should change the beginning of the 4 character plan name from Brai to WBHA for these cases.  This will be more consistent with naming convention.