### PR TITLE
Issue 93

### DIFF
--- a/general/autoplan_whole_brain.py
+++ b/general/autoplan_whole_brain.py
@@ -582,7 +582,7 @@ def main():
     case.PatientModel.ToggleExcludeFromExport(
         ExcludeFromExport=True,
         RegionOfInterests=export_exclude_structs,
-        PointsofInterests=[])
+        PointsOfInterests=[])
     # for s in export_exclude_structs:
     #    roi_name = str(s)
     #    try:

--- a/general/autoplan_whole_brain.py
+++ b/general/autoplan_whole_brain.py
@@ -583,13 +583,15 @@ def main():
             logging.debug("Structure: {} was not found".format(s))
     # Exclude these from export
     for s in export_exclude_structs:
+        roi_name = str(s)
         try:
-            case.PatientModel.ToggleExcludeFromExport(RegionOfInterests=[s])
+            case.PatientModel.ToggleExcludeFromExport(RegionOfInterests=[roi_name])
         except:
-            logging.warning('Unable to exclude {} from export'.format(s))
+            logging.warning('Unable to exclude {} from export'.format(roi_name))
 
-        if case.PatientModel.RegionsOfInterest[s].ExcludeFromExport == False:
-            logging.warning('Unable to exclude {} from export'.format(s))
+        logging.debug('S is {}'.format(roi_name))
+        if case.PatientModel.RegionsOfInterest[roi_name].ExcludeFromExport == False:
+            logging.warning('Unable to exclude {} from export'.format(roi_name))
 
 
     if make_plan:

--- a/general/autoplan_whole_brain.py
+++ b/general/autoplan_whole_brain.py
@@ -585,10 +585,12 @@ def main():
     for s in export_exclude_structs:
         try:
             case.PatientModel.ToggleExcludeFromExport(RegionOfInterests=[s])
-            if case.PatientModel.RegionsOfInterest[s].ExcludeFromExport == False:
-                logging.warning('Unable to exclude {} from export'.format(s))
         except:
             logging.warning('Unable to exclude {} from export'.format(s))
+
+        if case.PatientModel.RegionsOfInterest[s].ExcludeFromExport == False:
+            logging.warning('Unable to exclude {} from export'.format(s))
+
 
     if make_plan:
         try:

--- a/general/autoplan_whole_brain.py
+++ b/general/autoplan_whole_brain.py
@@ -66,10 +66,14 @@ import sys
 def check_external(roi_list):
     if any(roi.OfRoi.Type == 'External' for roi in roi_list):
         logging.debug('External contour designated')
+        return True
     else:
         logging.debug('No external contour designated')
         connect.await_user_input(
             'No External contour type designated. Give a contour an External type and continue script.')
+        if any(roi.OfRoi.Type == 'External' for roi in roi_list):
+            logging.debug('No external contour designated after prompt recommend exit')
+            return False
 
 
 def check_structure_exists(case, structure_name, roi_list, option):
@@ -314,7 +318,10 @@ def main():
             Examination=examination,
             ThresholdLevel=-250)
     else:
-        check_external(rois)
+        if not check_external(rois):
+            logging.warning('No External-Type Contour designated-Restart'
+                            ' script after choosing External-Type')
+            sys.exit
 
 
 

--- a/general/autoplan_whole_brain.py
+++ b/general/autoplan_whole_brain.py
@@ -717,7 +717,12 @@ def main():
 
     # Rename PTV per convention
     total_dose_string = str(int(total_dose))
-    case.PatientModel.RegionsOfInterest['PTV_WB_xxxx'].Name = 'PTV_WB_' + total_dose_string.zfill(4)
+    try:
+        case.PatientModel.RegionsOfInterest['PTV_WB_xxxx'].Name = 'PTV_WB_' + total_dose_string.zfill(4)
+    except Exception as e:
+        logging.debug('error reported {}'.format(e))
+        logging.debug('cannot do name change')
+
 
 
 

--- a/general/autoplan_whole_brain.py
+++ b/general/autoplan_whole_brain.py
@@ -585,6 +585,8 @@ def main():
     for s in export_exclude_structs:
         try:
             case.PatientModel.ToggleExcludeFromExport(RegionOfInterests=[s])
+            if case.PatientModel.RegionsOfInterest[s].ExcludeFromExport == False:
+                logging.warning('Unable to exclude {} from export'.format(s))
         except:
             logging.warning('Unable to exclude {} from export'.format(s))
 

--- a/general/autoplan_whole_brain.py
+++ b/general/autoplan_whole_brain.py
@@ -582,7 +582,7 @@ def main():
     case.PatientModel.ToggleExcludeFromExport(
         ExcludeFromExport=True,
         RegionOfInterests=export_exclude_structs,
-        PointsofInterest=[])
+        PointsofInterests=[])
     # for s in export_exclude_structs:
     #    roi_name = str(s)
     #    try:

--- a/general/autoplan_whole_brain.py
+++ b/general/autoplan_whole_brain.py
@@ -579,14 +579,19 @@ def main():
         except:
             logging.debug("Structure: {} was not found".format(s))
     # Exclude these from export
-    for s in export_exclude_structs:
-        roi_name = str(s)
-        try:
-            case.PatientModel.ToggleExcludeFromExport(RegionOfInterests=[roi_name])
-            if case.PatientModel.RegionsOfInterest[roi_name].ExcludeFromExport == False:
-                logging.info('RS8 Bug:Unable to exclude {} from export'.format(roi_name))
-        except:
-            logging.warning('Unable to exclude {} from export'.format(roi_name))
+    case.PatientModel.ToggleExcludeFromExport(
+        ExcludeFromExport=True,
+        RegionOfInterests=export_exclude_structs,
+        PointsofInterest=[])
+    # for s in export_exclude_structs:
+    #    roi_name = str(s)
+    #    try:
+    #        case.PatientModel.ToggleExcludeFromExport(
+    #            ExcludeFromExport=True,
+    #            RegionOfInterests=[roi_name],
+    #            PointsofInterest=[])
+    #    except:
+    #        logging.warning('Unable to exclude {} from export'.format(roi_name))
 
     if make_plan:
         try:

--- a/general/autoplan_whole_brain.py
+++ b/general/autoplan_whole_brain.py
@@ -236,10 +236,7 @@ def main():
     total_dose = float(input_dialog.values['input3_dose'])
     plan_machine = input_dialog.values['input4_choose_machine']
 
-
-
-
-        ## patient.Save()
+    ## patient.Save()
 
     # MBS generate the globes. Manually draw lenses
     status.next_step(text="Regions at risk will be created including Globes, Lenses, and Brain.")
@@ -397,7 +394,7 @@ def main():
         Examination=examination,
         Algorithm="Auto")
 
-    #S - frame loading
+    # S - frame loading
     status.next_step(text="Roi contouring complete, loading patient immobilization.")
     # Load the S-frame into the current scan based on the structure template input above.
     # This operation is not supported in RS7, however, when we convert to RS8, this should work
@@ -586,13 +583,10 @@ def main():
         roi_name = str(s)
         try:
             case.PatientModel.ToggleExcludeFromExport(RegionOfInterests=[roi_name])
+            if case.PatientModel.RegionsOfInterest[roi_name].ExcludeFromExport == False:
+                logging.info('RS8 Bug:Unable to exclude {} from export'.format(roi_name))
         except:
             logging.warning('Unable to exclude {} from export'.format(roi_name))
-
-        logging.debug('S is {}'.format(roi_name))
-        if case.PatientModel.RegionsOfInterest[roi_name].ExcludeFromExport == False:
-            logging.warning('Unable to exclude {} from export'.format(roi_name))
-
 
     if make_plan:
         try:
@@ -601,7 +595,7 @@ def main():
         except:
             logging.debug("Could not click on the plan Design MenuItem")
 
-        plan_names = [plan_name,'backup_r1a0']
+        plan_names = [plan_name, 'backup_r1a0']
         # RS 8: plan_names = [plan_name]
         patient.Save()
         # RS 8: eliminate for loop
@@ -706,7 +700,7 @@ def main():
                 ForceRecompute=False)
 
         # RS 8 delete next three lines
-        plan_name_regex = '^'+plan_names[0]+'$'
+        plan_name_regex = '^' + plan_names[0] + '$'
         plan_information = case.QueryPlanInfo(Filter={'Name': plan_name_regex})
         case.LoadPlan(PlanInfo=plan_information[0])
         try:
@@ -722,9 +716,6 @@ def main():
     except Exception as e:
         logging.debug('error reported {}'.format(e))
         logging.debug('cannot do name change')
-
-
-
 
 
 if __name__ == '__main__':

--- a/general/autoplan_whole_brain.py
+++ b/general/autoplan_whole_brain.py
@@ -313,6 +313,9 @@ def main():
         case.PatientModel.RegionsOfInterest['External'].CreateExternalGeometry(
             Examination=examination,
             ThresholdLevel=-250)
+    else:
+        check_external(rois)
+
 
 
     if not check_structure_exists(case=case, roi_list=rois, option='Delete', structure_name='Lens_L_PRV05'):
@@ -666,13 +669,9 @@ def main():
             # Set the BTV type above to allow dose grid to cover
             case.PatientModel.RegionsOfInterest['BTV'].Type = 'Ptv'
             case.PatientModel.RegionsOfInterest['BTV'].OrganData.OrganType = 'Target'
-            if check_external(rois):
-                plan.SetDefaultDoseGrid(VoxelSize={'x': 0.2,
-                                                   'y': 0.2,
-                                                   'z': 0.2})
-            else:
-                logging.warning('No contour set as External-Type')
-                sys.exit
+            plan.SetDefaultDoseGrid(VoxelSize={'x': 0.2,
+                                               'y': 0.2,
+                                               'z': 0.2})
             try:
                 isocenter_position = case.PatientModel.StructureSets[examination.Name]. \
                     RoiGeometries['PTV_WB_xxxx'].GetCenterOfRoi()

--- a/general/autoplan_whole_brain.py
+++ b/general/autoplan_whole_brain.py
@@ -584,7 +584,7 @@ def main():
     # Exclude these from export
     for s in export_exclude_structs:
         try:
-            case.PatientModel.ToggleExcludeFromExport(RegionsOfInterests=[s])
+            case.PatientModel.ToggleExcludeFromExport(RegionOfInterests=[s])
         except:
             logging.warning('Unable to exclude {} from export'.format(s))
 

--- a/general/planning_structures.py
+++ b/general/planning_structures.py
@@ -126,7 +126,7 @@ def make_boolean_structure(patient, case, examination, **kwargs):
         case.PatientModel.ToggleExcludeFromExport(
             ExcludeFromExport=ExcludeFromExport,
             RegionOfInterests=[StructureName],
-            PointsofInterest=[])
+            PointsofInterests=[])
     except:
         logging.warning('Unable to exclude {} from export'.format(StructureName))
     case.PatientModel.RegionsOfInterest[StructureName].UpdateDerivedGeometry(

--- a/general/planning_structures.py
+++ b/general/planning_structures.py
@@ -124,9 +124,9 @@ def make_boolean_structure(patient, case, examination, **kwargs):
                               'Left': ExpR[5]})
     try:
         case.PatientModel.ToggleExcludeFromExport(
-            ExcludeFromExport=ExcludeFromExport,
+            ExcludeFromExport=True,
             RegionOfInterests=[StructureName],
-            PointsofInterests=[])
+            PointsOfInterests=[])
     except:
         logging.warning('Unable to exclude {} from export'.format(StructureName))
     case.PatientModel.RegionsOfInterest[StructureName].UpdateDerivedGeometry(

--- a/general/planning_structures.py
+++ b/general/planning_structures.py
@@ -122,8 +122,12 @@ def make_boolean_structure(patient, case, examination, **kwargs):
                               'Posterior': ExpR[3],
                               'Right': ExpR[4],
                               'Left': ExpR[5]})
-    case.PatientModel.ToggleEx
-    case.PatientModel.RegionsOfInterest[StructureName].ExcludeFromExport = ExcludeFromExport
+    try:
+        case.PatientModel.ToggleExcludeFromExport(RegionOfInterests=[StructureName]
+        if case.PatientModel.RegionsOfInterest[StructureName].ExcludeFromExport == False:
+            logging.info('RS8 Bug:Unable to exclude {} from export'.format(StructureName))
+    except:
+        logging.warning('Unable to exclude {} from export'.format(StructureName))
     case.PatientModel.RegionsOfInterest[StructureName].UpdateDerivedGeometry(
         Examination=examination, Algorithm="Auto")
     patient.SetRoiVisibility(RoiName=StructureName,

--- a/general/planning_structures.py
+++ b/general/planning_structures.py
@@ -122,6 +122,7 @@ def make_boolean_structure(patient, case, examination, **kwargs):
                               'Posterior': ExpR[3],
                               'Right': ExpR[4],
                               'Left': ExpR[5]})
+    case.PatientModel.ToggleEx
     case.PatientModel.RegionsOfInterest[StructureName].ExcludeFromExport = ExcludeFromExport
     case.PatientModel.RegionsOfInterest[StructureName].UpdateDerivedGeometry(
         Examination=examination, Algorithm="Auto")

--- a/general/planning_structures.py
+++ b/general/planning_structures.py
@@ -123,9 +123,10 @@ def make_boolean_structure(patient, case, examination, **kwargs):
                               'Right': ExpR[4],
                               'Left': ExpR[5]})
     try:
-        case.PatientModel.ToggleExcludeFromExport(RegionOfInterests=[StructureName]
-        if case.PatientModel.RegionsOfInterest[StructureName].ExcludeFromExport == False:
-            logging.info('RS8 Bug:Unable to exclude {} from export'.format(StructureName))
+        case.PatientModel.ToggleExcludeFromExport(
+            ExcludeFromExport=ExcludeFromExport,
+            RegionOfInterests=[StructureName],
+            PointsofInterest=[])
     except:
         logging.warning('Unable to exclude {} from export'.format(StructureName))
     case.PatientModel.RegionsOfInterest[StructureName].UpdateDerivedGeometry(


### PR DESCRIPTION
RS 8b upgrade: The ExcludeFromExport attibute can no longer be changed directly. Instead you must use:
case.PatientModel.ToggleExcludeFromExport(RegionsOfInterests=[s])
where s is a list. This affects autoplan and planning_structs. 

Improved error handling for the autowholebrain script to force user to designate an external.