### PR TITLE
Issue 128

### DIFF
--- a/general/FinalDose.py
+++ b/general/FinalDose.py
@@ -143,7 +143,8 @@ def main():
                                  'due to no structures having type Support')
                 external_error = False
             elif len(error) != 0:
-                connect.await_user_input('Eliminate overlap of patient external with support structures')
+                connect.await_user_input('Eliminate overlap of patient external with support structures' +
+                                         ' (hint: use the Couch Removal tool on the external)')
             else:
                 external_error = False
         status.next_step('Reviewed external')

--- a/general/FinalDose.py
+++ b/general/FinalDose.py
@@ -39,7 +39,6 @@ __copyright__ = 'Copyright (C) 2018, University of Wisconsin Board of Regents'
 
 import logging
 import sys
-import unicodedata
 import connect
 import UserInterface
 import BeamOperations
@@ -51,7 +50,6 @@ import StructureOperations
 import clr
 clr.AddReference("System.Xml")
 import System
-import inspect
 
 
 class MyException(Exception):

--- a/general/FinalDose.py
+++ b/general/FinalDose.py
@@ -133,7 +133,7 @@ def main():
 
     # EXTERNAL OVERLAP WITH COUCH OR SUPPORTS
     if external_test:
-        external_error = False
+        external_error = True
         while external_error:
             error = PlanQualityAssuranceTests.external_overlap_test(patient, case, exam)
             if len(error) != 0:
@@ -177,7 +177,7 @@ def main():
     # SIMFIDUCIAL TEST
     if simfid_test:
         fiducial_point = 'SimFiducials'
-        fiducial_error = False
+        fiducial_error = True
         while fiducial_error:
             error = PlanQualityAssuranceTests.simfiducial_test(case=case, exam=exam, poi=fiducial_point)
             if len(error) != 0:

--- a/general/UpdateScripts.py
+++ b/general/UpdateScripts.py
@@ -82,6 +82,7 @@ def main():
                     try:
                         if os.path.isfile(file_path) or os.path.islink(file_path):
                             os.unlink(file_path)
+                            time.sleep(1)
                         elif os.path.isdir(file_path):
                             shutil.rmtree(file_path, ignore_errors=True)
                             time.sleep(1)

--- a/general/automated_plan_optimization.py
+++ b/general/automated_plan_optimization.py
@@ -72,6 +72,7 @@ import connect
 import UserInterface
 import OptimizationOperations
 
+
 def main():
     try:
         Patient = connect.get_current("Patient")
@@ -111,14 +112,17 @@ def main():
             'input08_n_iterations': 'Number of Iterations',
             'input09_segment_weight': 'Segment weight calculation',
             'input10_reduce_oar': 'Reduce OAR Dose',
-            'input11_small_target': 'Target size < 3 cm'},
+            # Small Target
+            # 'input11_small_target': 'Target size < 3 cm'
+        },
         datatype={
             'input07_vary_dose_grid': 'check',
             'input01_fluence_only': 'check',
             'input02_cold_start': 'check',
             'input09_segment_weight': 'check',
             'input10_reduce_oar': 'check',
-            'input11_small_target': 'check'},
+            # 'input11_small_target': 'check'
+        },
         initial={'input03_cold_max_iteration': '50',
                  'input04_cold_interm_iteration': '10',
                  'input05_ws_max_iteration': '35',
@@ -126,14 +130,18 @@ def main():
                  'input08_n_iterations': '4',
                  'input09_segment_weight': ['Perform Segment Weighted optimization'],
                  'input10_reduce_oar': ['Perform reduce OAR dose before completion'],
-                 'input11_small_target': ['Target size < 3 cm - limit jaws']},
+                 # Small Target
+                 # 'input11_small_target': ['Target size < 3 cm - limit jaws']
+                 },
         options={
             'input01_fluence_only': ['Fluence calc'],
             'input02_cold_start': ['Reset Beams'],
             'input07_vary_dose_grid': ['Variable Dose Grid'],
             'input09_segment_weight': ['Perform Segment Weighted optimization'],
             'input10_reduce_oar': ['Perform reduce OAR dose before completion'],
-            'input11_small_target': ['Target size < 3 cm - limit jaws']},
+            # Small Target
+            # 'input11_small_target': ['Target size < 3 cm - limit jaws']
+        },
         required=[])
     optimization_dialog.show()
 
@@ -183,13 +191,14 @@ def main():
     except KeyError:
         reduce_oar = False
     # Despite a calculated beam, reset and start over
-    try:
-        if 'Target size < 3 cm - limit jaws' in optimization_dialog.values['input11_small_target']:
-            small_target = True
-        else:
-            small_target = False
-    except KeyError:
-        small_target = False
+    # Small Target
+    # try:
+    #     if 'Target size < 3 cm - limit jaws' in optimization_dialog.values['input11_small_target']:
+    #         small_target = True
+    #     else:
+    #         small_target = False
+    # except KeyError:
+    #     small_target = False
     optimization_inputs = {
         'initial_max_it': int(optimization_dialog.values['input03_cold_max_iteration']),
         'initial_int_it': int(optimization_dialog.values['input04_cold_interm_iteration']),
@@ -204,14 +213,16 @@ def main():
         'reset_beams': reset_beams,
         'segment_weight': segment_weight,
         'reduce_oar': reduce_oar,
-        'small_target': small_target,
+        'save': True,
+        # Small Target
+        # 'small_target': small_target,
         'n_iterations': int(optimization_dialog.values['input08_n_iterations'])}
 
     OptimizationOperations.optimize_plan(patient=Patient,
-                  case=case,
-                  plan=plan,
-                  beamset=beamset,
-                  **optimization_inputs)
+                                         case=case,
+                                         plan=plan,
+                                         beamset=beamset,
+                                         **optimization_inputs)
 
 
 if __name__ == '__main__':

--- a/library/BeamOperations.py
+++ b/library/BeamOperations.py
@@ -1315,8 +1315,8 @@ def rounded_jaw_positions(beam):
         y1_eclipse = math.floor(10 * (y1_min - y_jaw_offset)) / 10
         y2_eclipse = math.ceil(10 * (y2_max + y_jaw_offset)) / 10
         logging.debug('Beam: {} Eclipse offsets would be: '.format(beam.Name) +
-                      'X1:Floor[{} - {} cm] = {}, '.format(min_a, x_jaw_offset, x1_eclipse) +
-                      'X2:Ceil[{} + {} cm] = {}, '.format(max_b, x_jaw_offset, x2_eclipse) +
+                      'X1:Floor[{} - {} cm] = {}, '.format(max_a, x_jaw_offset, x1_eclipse) +
+                      'X2:Ceil[{} + {} cm] = {}, '.format(min_b, x_jaw_offset, x2_eclipse) +
                       'Y1:Floor[{} - {} cm] = {}, '.format(y1_min, y_jaw_offset, y1_eclipse) +
                       'Y2:Ceil[{} + {} cm] = {}'.format(y2_max, y_jaw_offset, y2_eclipse))
     else:

--- a/library/BeamOperations.py
+++ b/library/BeamOperations.py
@@ -401,12 +401,13 @@ def place_tomo_beam_in_beamset(plan, iso, beamset, beam):
     :param beams: list of Beam objects
     :return:
     """
+    verbose_logging = False
     logging.info(('Loading Beam {}. Type {}, Name {}, Energy {}, StartAngle {}, StopAngle {}, ' +
                   'RotationDirection {}, CollimatorAngle {}, CouchAngle {} ').format(
-        beam.number, beam.technique, beam.name,
+        beam.number, beam.technique, beam.Name,
         beam.energy))
 
-    beamset.CreatePhotonBeam(Name=beam.Name,
+    beamset.CreatePhotonBeam(Name=beam.name,
                              Energy=beam.energy,
                              IsocenterData=iso,
                              Description=beam.name,
@@ -420,9 +421,9 @@ def place_tomo_beam_in_beamset(plan, iso, beamset, beam):
             ts_settings = tss
             if verbose_logging:
                 logging.debug('TreatmentSetupSettings:{} matches Beamset:{} looking for beam {}'.format(
-                    tss.ForTreatmentSetup.DicomPlanLabel, beamset.DicomPlanLabel, beam_name))
+                    tss.ForTreatmentSetup.DicomPlanLabel, beamset.DicomPlanLabel, beam.name))
             for bs in ts_settings.BeamSettings:
-                if bs.ForBeam.Name == beam_name:
+                if bs.ForBeam.Name == beam.name:
                     beam_found = True
                     current_beam = bs
                     break
@@ -437,9 +438,9 @@ def place_tomo_beam_in_beamset(plan, iso, beamset, beam):
 
     if not beam_found:
         logging.warning('Beam {} not found in beam list from {}'.format(
-            beam_name, beamset.DicomPlanLabel))
+            beam.name, beamset.DicomPlanLabel))
         sys.exit('Could not find a beam match for setting aperture limits')
-    plan.PlanOptimizations[opt_index].OptimizationParameters.
+   # plan.PlanOptimizations[opt_index].OptimizationParameters.
 
 
 

--- a/library/BeamOperations.py
+++ b/library/BeamOperations.py
@@ -1236,12 +1236,13 @@ def check_y_jaw_positions(jaw_positions, beam):
         logging.debug('beam: {} is a jaw-only field, without segments'.format(beam.Name))
         return error
 
-    # Maximum MLC defined positions: Leaf Center + 0.5 Leaf_Width
+    # Maximum MLC defined positions: Leaf Center + 0.2 Leaf_Width this ensures at least a full millimeter
+    # of cushion for jaw inaccuracies on a 5 mm leaf and 2 mm on a 1 cm leaf
     max_y1_jaw_limit = beam.UpperLayer.LeafCenterPositions[0] - \
-        0.5 * beam.UpperLayer.LeafWidths[0]
+        0.2 * beam.UpperLayer.LeafWidths[0]
     n_leaves = len(beam.UpperLayer.LeafCenterPositions)
     max_y2_jaw_limit = beam.UpperLayer.LeafCenterPositions[n_leaves - 1] + \
-        0.5 * beam.UpperLayer.LeafWidths[n_leaves - 1]
+        0.2 * beam.UpperLayer.LeafWidths[n_leaves - 1]
 
     # Check jaws
     if jaw_positions['Y1'] > min_y1_jaw_limit:
@@ -1257,15 +1258,6 @@ def check_y_jaw_positions(jaw_positions, beam):
         error += 'Beam {}: Y2 jaw position exceeds MLC-delineated boundary at Y2 = {}'.format(
             beam.Name, jaw_positions['Y2'])
 
-    # if 'TrueBeamSTx' in beam.MachineReference.MachineName:
-    #     if abs(jaw_positions['Y1']) > 10.9:
-    #         logging.debug('Maximum Y1 jaw limit exceeded for proposed setting on Beam {}'.format(
-    #             beam.Name))
-    #         error = 'Beam {}: Proposed Y1 Setting exceeds machine limits. '.format(beam.Name)
-    #     if abs(jaw_positions['Y2']) < 10.9:
-    #         logging.debug('Maximum Y2 jaw limit exceeded for proposed setting on Beam {}'.format(
-    #             beam.Name))
-    #         error += 'Beam {}: Proposed Y2 Setting exceeds machine limits'.format(beam.Name)
     return error
 
 
@@ -1301,7 +1293,7 @@ def rounded_jaw_positions(beam):
         leaf_index_upper = np.max(np.nonzero(ciao[:, 1] - ciao[:, 0]))
         logging.debug('Beam: {} has top leaf opening at {}, '.format(beam.Name, leaf_index_upper+1) +
                       'bottom leaf opening at {}'.format(leaf_index_lower+1))
-        logging.debug('Min X1: {}'.format(ciao[i, 0] for i in ciao[:, 0]))
+        logging.debug('Min X1: {}'.format(np.array2string(ciao[:, 0], precision=2, separator=',',suppress_small=True)))
         min_x1_bank = np.amin(ciao[:, 0], axis=0)
         max_x2_bank = np.amax(ciao[:, 1], axis=0)
         x1_eclipse = math.floor(10 * (min_x1_bank - x_jaw_offset)) / 10

--- a/library/BeamOperations.py
+++ b/library/BeamOperations.py
@@ -1187,11 +1187,11 @@ class mlc_properties:
                 self.banks = np.dstack((self.banks, bank))
 
             # Determine if leaves are in retracted position
-            if all(self.banks[:, 0, :] <= - self.max_tip):
+            if np.all(self.banks[:, 0, :] <= - self.max_tip):
                 x1_bank_retracted = True
             else:
                 x1_bank_retracted = False
-            if all(self.banks[:, 1, :] >= self.max_tip):
+            if np.all(self.banks[:, 1, :] >= self.max_tip):
                 x2_bank_retracted = True
             else:
                 x2_bank_retracted = False

--- a/library/BeamOperations.py
+++ b/library/BeamOperations.py
@@ -1312,13 +1312,13 @@ def check_mlc_jaw_positions(jaw_positions, mlc_positions):
     error = ''
     # if ciao is not None:
     #     ciao = maximum_leaf_carriage_extent(beam=beam)
-    ciao = mlc_properties.ciao()
+    mlc_ciao = mlc_positions.ciao()
     # Find the maximally extended MLC in each bank
-    max_x1_bank = np.amax(ciao[:, 0], axis=0)
-    min_x2_bank = np.amin(ciao[:, 1], axis=0)
+    max_x1_bank = np.amax(mlc_ciao[:, 0], axis=0)
+    min_x2_bank = np.amin(mlc_ciao[:, 1], axis=0)
 
     # delta's are the maximum extent of the MLC leaves away from the jaw for this segment
-    if ciao is not None:
+    if mlc_ciao is not None:
         delta_x1 = jaw_positions['X1'] - max_x1_bank
         delta_x2 = jaw_positions['X2'] - min_x2_bank
     else:

--- a/library/BeamOperations.py
+++ b/library/BeamOperations.py
@@ -1450,11 +1450,11 @@ def rounded_jaw_positions(beam):
                  +0.5 * current_mlc_physics.UpperLayer.LeafWidths[leaf_index_upper]
         y1_eclipse = math.floor(10 * (y1_min - y_jaw_offset)) / 10
         y2_eclipse = math.ceil(10 * (y2_max + y_jaw_offset)) / 10
-        logging.debug('Beam: {} Eclipse offsets would be: '.format(beam.Name) +
-                      'X1:Floor[{} - {} cm] = {}, '.format(min_x1_bank, x_jaw_offset, x1_eclipse) +
-                      'X2:Ceil[{} + {} cm] = {}, '.format(max_x2_bank, x_jaw_offset, x2_eclipse) +
-                      'Y1:Floor[{} - {} cm] = {}, '.format(y1_min, y_jaw_offset, y1_eclipse) +
-                      'Y2:Ceil[{} + {} cm] = {}'.format(y2_max, y_jaw_offset, y2_eclipse))
+        # logging.debug('Beam: {} Eclipse offsets would be: '.format(beam.Name) +
+        #               'X1:Floor[{} - {} cm] = {}, '.format(min_x1_bank, x_jaw_offset, x1_eclipse) +
+        #               'X2:Ceil[{} + {} cm] = {}, '.format(max_x2_bank, x_jaw_offset, x2_eclipse) +
+        #               'Y1:Floor[{} - {} cm] = {}, '.format(y1_min, y_jaw_offset, y1_eclipse) +
+        #               'Y2:Ceil[{} + {} cm] = {}'.format(y2_max, y_jaw_offset, y2_eclipse))
     else:
         # There's no segments. This is a jaw-only field. Use open settings
         if beam_mlc.mlc_retracted:
@@ -1510,7 +1510,7 @@ def rounded_jaw_positions(beam):
             jaw_positions['X2'] = round_open_r_jaw
             debug_msg = error_msg + ' X-Jaws: Rounded open'.format(beam.Name)
         elif i == 2:
-            jaw_positions['X1'] = round_closed_l_jaw,
+            jaw_positions['X1'] = round_closed_l_jaw
             jaw_positions['X2'] = round_closed_r_jaw
             debug_msg = error_msg + ' X-Jaws: Rounded closed'.format(beam.Name)
         else:

--- a/library/BeamOperations.py
+++ b/library/BeamOperations.py
@@ -1636,9 +1636,10 @@ def find_dsp(plan, beam_set, dose_per_fraction=None, Beam=None):
     zsize = plan.TreatmentCourse.TotalDose.InDoseGrid.VoxelSize.z
 
     if np.amax(pd_np) < rx:
-        logging.debug('max = {}'.format(max(pd)))
+        logging.debug('max = {}'.format(np.amax(pd_np)))
         logging.debug('target = {}'.format(rx))
-        raise ValueError('max beam dose is too low')
+        raise ValueError('Max beam dose is too low. Cannot find a DSP. Max Dose in Beamset is {}, for Rx {}'.format(
+            np.amax(pd_np), rx))
 
     rx_points = np.array([])
     while rx_points.size == 0:

--- a/library/BeamOperations.py
+++ b/library/BeamOperations.py
@@ -1308,7 +1308,7 @@ def check_mlc_jaw_positions(jaw_positions, mlc_positions):
     """
 
     # Maximum a single leaf can extend from the carriage (jaw)
-    maximum_leaf_out_of_carriage = mlc_properties.max_leaf_carriage
+    maximum_leaf_out_of_carriage = mlc_positions.max_leaf_carriage
     error = ''
     # if ciao is not None:
     #     ciao = maximum_leaf_carriage_extent(beam=beam)

--- a/library/BeamOperations.py
+++ b/library/BeamOperations.py
@@ -1312,13 +1312,13 @@ def check_mlc_jaw_positions(jaw_positions, mlc_positions):
     error = ''
     # if ciao is not None:
     #     ciao = maximum_leaf_carriage_extent(beam=beam)
-    mlc_ciao = mlc_positions.ciao()
+    max_travel = mlc_positions.max_travel()
     # Find the maximally extended MLC in each bank
-    max_x1_bank = np.amax(mlc_ciao[:, 0], axis=0)
-    min_x2_bank = np.amin(mlc_ciao[:, 1], axis=0)
+    max_x1_bank = np.amax(max_travel[:, 0], axis=0)
+    min_x2_bank = np.amin(max_travel[:, 1], axis=0)
 
     # delta's are the maximum extent of the MLC leaves away from the jaw for this segment
-    if mlc_ciao is not None:
+    if max_travel is not None and not mlc_positions.mlc_retracted:
         delta_x1 = jaw_positions['X1'] - max_x1_bank
         delta_x2 = jaw_positions['X2'] - min_x2_bank
     else:
@@ -1419,7 +1419,7 @@ def rounded_jaw_positions(beam):
 
     ciao = beam_mlc.ciao()
 
-    if not beam_mlc.mlc_retracted:
+    if not beam_mlc.mlc_retracted or ciao is None:
         # Now find the maximum Top and Bottom MLC positions
         # Raystation starts moving leaves to the midplane, so we want to find the first open, and
         # last open MLC leaf pair.
@@ -1446,6 +1446,9 @@ def rounded_jaw_positions(beam):
                       'Y2:Ceil[{} + {} cm] = {}'.format(y2_max, y_jaw_offset, y2_eclipse))
     else:
         # There's no segments. This is a jaw-only field. Use open settings
+        if beam_mlc.mlc_retracted:
+            logging.debug('MLC is retracted. Proceeding with jaw-only field settings')
+
         x1_eclipse = round_open_l_jaw
         x2_eclipse = round_open_r_jaw
         y1_eclipse = round_open_t_jaw

--- a/library/OptimizationOperations.py
+++ b/library/OptimizationOperations.py
@@ -840,6 +840,11 @@ def optimize_plan(patient, case, plan, beamset, **optimization_inputs):
                 Optimization_Iteration, plan_optimization.Objective.FunctionValue))
 
     report_inputs['time_total_final'] = datetime.datetime.now()
+    try:
+        patient.Save()
+    except:
+        logging.debug('Could not save patient plan')
+
     on_screen_message = optimization_report(
         fluence_only=fluence_only,
         vary_grid=vary_grid,

--- a/library/OptimizationOperations.py
+++ b/library/OptimizationOperations.py
@@ -155,6 +155,92 @@ def make_variable_grid_list(n_iterations, variable_dose_grid):
     return change_grid
 
 
+def select_rois_for_treat(plan, beamset, rois=None):
+    """ For the beamset supplie set treat settings
+    :param beamset: RS beamset or ForTreatmentSetup object
+    :param rois: a list of strings of roi names
+    :return roi_list: a list of rois that were set to allow Treat Margins for this beamset"""
+    # Find the plan optimization for this beamset
+    target_objectives = ['MinDose', 'UniformDose', 'TargetEud']
+    function_types = ['CompositeDose']
+    roi_list = []
+    if rois is None:
+        OptIndex = PlanOperations.find_optimization_index(plan=plan, beamset=beamset, verbose_logging=False)
+        plan_optimization = plan.PlanOptimizations[OptIndex]
+        # Look for co-optimization - Treatment setup settings is an array if there is cooptimization
+        if len(plan_optimization.OptimizationParameters.TreatmentSetupSettings) > 1:
+            cooptimization=True
+        else:
+            cooptimization=False
+            objective_beamset_name = None
+        for o in plan_optimization.Objective.ConstituentFunctions:
+            roi_name = o.ForRegionOfInterest.Name
+            try:
+                objective_function_type = o.DoseFunctionParameters.FunctionType
+            except AttributeError:
+                logging.debug('Objective type for roi {} is not associated with target and is ignored'.format(
+                    roi_name) + ' from treat settings.')
+                objective_function_type = None
+            # Non-cooptimized objectives have no ForBeamSet object
+            if cooptimization:
+                try:
+                    objective_beamset_name = o.OfDoseDistribution.ForBeamSet.DicomPlanLabel
+                except AttributeError:
+                    logging.debug('Objective for roi {} is not defined on a specific beamset'.format(
+                     roi_name) + ' and is not included in treat settings.')
+                    objective_beamset_name = None
+
+            if not cooptimization or objective_beamset_name == beamset.DicomPlanLabel:
+                roi_in_scope = True
+            else:
+                roi_in_scope = False
+
+            if objective_function_type in target_objectives and \
+                    roi_in_scope and \
+                    roi_name not in roi_list:
+                roi_list.append(roi_name)
+        for r in roi_list:
+            beamset.SelectToUseROIasTreatOrProtectForAllBeams(RoiName=r)
+            logging.debug('Roi {} added to list for treat margins for beamset {}'.format(
+                r, objective_beamset_name))
+    else:
+        for r in rois:
+            try:
+                beamset.SelectToUseROIasTreatOrProtectForAllBeams(RoiName=r)
+            except Exception as e:
+                try:
+                    if 'No ROI named' in e.Message:
+                        logging.info('TreatProtect settings failed for roi {} since it does not exist'.format(
+                            r))
+                    else:
+                        logging.exception(u'{}'.format(e.Message))
+                        sys.exit(u'{}'.format(e.Message))
+                except:
+                    logging.exception(u'{}'.format(e.Message))
+                    sys.exit(u'{}'.format(e.Message))
+            if r not in roi_list:
+                roi_list.append(r)
+    return roi_list
+
+
+def set_treat_margins(beam, rois, margins=None):
+    """ Find the ROI's in this beamset that have a target type that are used in
+        the optimization. Look at the plan name to define an aperature setting for
+        the Treat Margins"""
+    # TODO add functionality for single roi
+    if margins is None:
+        margins = {'Y1': 0.8, 'Y2': 0.8, 'X1': 0.8, 'X2': 0.8}
+
+    logging.debug('rois in set_treat margins are {}'.format(rois))
+    for r in rois:
+        logging.debug('r in set_treat margins is {}'.format(r))
+        beam.SetTreatAndProtectMarginsForBeam(TopMargin=margins['Y2'],
+                                              BottomMargin=margins['Y1'],
+                                              RightMargin=margins['X2'],
+                                              LeftMargin=margins['X1'],
+                                              Roi=r)
+
+
 def check_min_jaws(plan_opt, min_dim):
     """
     This function takes in the beamset, looks for field sizes that are less than a minimum
@@ -498,8 +584,6 @@ def optimize_plan(patient, case, plan, beamset, **optimization_inputs):
     maximum_iteration = optimization_inputs.get('n_iterations', 12)
     fluence_only = optimization_inputs.get('fluence_only', False)
     reset_beams = optimization_inputs.get('reset_beams', True)
-    # Small target
-    # small_target = optimization_inputs.get('small_target', True)
     reduce_oar = optimization_inputs.get('reduce_oar', True)
     segment_weight = optimization_inputs.get('segment_weight', False)
     gantry_spacing = optimization_inputs.get('gantry_spacing', 2)
@@ -554,9 +638,6 @@ def optimize_plan(patient, case, plan, beamset, **optimization_inputs):
             if vary_grid:
                 if change_dose_grid[i] != 0:
                     status_steps.append('Change dose grid to: {} cm'.format(change_dose_grid[i]))
-            # Small target
-            # if small_target and i == 0:
-            #     status_steps.append('Test iteration for jaw offset.')
             ith_step = 'Complete Iteration:' + str(i + 1)
             status_steps.append(ith_step)
         if segment_weight:
@@ -589,7 +670,6 @@ def optimize_plan(patient, case, plan, beamset, **optimization_inputs):
     Optimization_Iteration = 0
 
     # SNS Properties
-    num_beams = 0
     maximum_segments_per_beam = 10  # type: int
     min_leaf_pairs = '2'  # type: str
     min_leaf_end_separation = '0.5'  # type: str
@@ -597,11 +677,17 @@ def optimize_plan(patient, case, plan, beamset, **optimization_inputs):
     min_segment_area = '2'
     min_segment_mu = '2'
 
-    if 'PRD' in beamset.DicomPlanLabel:
+    if '_PRD_' in beamset.DicomPlanLabel:
         min_segment_area = '4'
         min_segment_mu = '6'
         logging.info('PRDR plan detected, setting minimum area to {} and minimum mu to {}'.format(
             min_segment_area, min_segment_mu))
+
+    # TODO: Make this a beamset setting in the xml protocols
+    if '_SBR_' in beamset.DicomPlanLabel:
+        margins = {'Y1': 0.3, 'Y2': 0.3, 'X1': 0.3, 'X2': 0.3}
+    else:
+        margins = {'Y1': 0.8, 'Y2': 0.8, 'X1': 0.8, 'X2': 0.8}
 
     # Find current Beamset Number and determine plan optimization
     OptIndex = PlanOperations.find_optimization_index(plan=plan, beamset=beamset, verbose_logging=False)
@@ -624,7 +710,7 @@ def optimize_plan(patient, case, plan, beamset, **optimization_inputs):
     # How many beams are there in this beamset
     # Set the control point spacing
     treatment_setup_settings = plan_optimization_parameters.TreatmentSetupSettings
-    if len(plan_optimization_parameters.TreatmentSetupSettings) > 1:
+    if len(treatment_setup_settings) > 1:
         cooptimization = True
         logging.debug('Plan is co-optimized with {} other plans'.format(
             len(plan_optimization_parameters.TreatmentSetupSettings)))
@@ -672,38 +758,49 @@ def optimize_plan(patient, case, plan, beamset, **optimization_inputs):
         logging.info('Full optimization')
         for ts in treatment_setup_settings:
             # Set properties of the beam optimization
-
-            for beams in ts.BeamSettings:
-                mu = beams.ForBeam.BeamMU
-                if beams.TomoPropertiesPerBeam is not None:
-                    logging.debug('Tomo plan - control point spacing not set')
-                elif beams.ForBeam.DeliveryTechnique == 'SMLC':
+            if ts.ForTreatmentSetup.DeliveryTechnique == 'TomoHelical':
+                logging.debug('Tomo plan - control point spacing not set')
+            elif ts.ForTreatmentSetup.DeliveryTechnique == 'SMLC':
+                #
+                # Execute treatment margin settings
+                treat_rois = select_rois_for_treat(plan, beamset=ts.ForTreatmentSetup, rois=None)
+                for beams in ts.BeamSettings:
+                    mu = beams.ForBeam.BeamMU
                     if mu > 0:
-                        logging.debug('This beamset is already optimized with beamsplitting not applied')
+                        logging.debug('This beamset is already optimized. Not applying treat settings to targets')
+                    else:
+                        set_treat_margins(beam=beams.ForBeam, rois=treat_rois, margins=margins)
+                #
+                # Set beam splitting preferences
+                for beams in ts.BeamSettings:
+                    if mu > 0:
+                        logging.debug('This beamset is already optimized beam-splitting preferences not applied')
                     else:
                         beams.AllowBeamSplit = allow_beam_split
-                elif beams.ArcConversionPropertiesPerBeam is not None:
-                    # Set the control point spacing for Arc Beams
-                    if beams.ArcConversionPropertiesPerBeam.FinalArcGantrySpacing > 2:
-                        if mu > 0:
-                            # If there are MU then this field has already been optimized with the wrong gantry
-                            # spacing. For shame....
-                            logging.info('This beamset is already optimized with > 2 degrees.  Reset needed')
-                            UserInterface.WarningBox('Restart Required: Attempt to correct final gantry ' +
-                                                     'spacing failed - check reset beams' +
-                                                     ' on next attempt at this script')
-                            status.finish('Restart required')
-                            sys.exit('Restart Required: Select reset beams on next run of script.')
-                        else:
-                            beams.ArcConversionPropertiesPerBeam.EditArcBasedBeamOptimizationSettings(
-                                FinalGantrySpacing=2)
-                    # Maximum Jaw Sizes should be limited for STx beams
-                    # Determine the current machine
-                    machine_ref = beamset.MachineReference.MachineName
-                    if machine_ref == 'TrueBeamSTx':
-                        logging.info('Current Machine is {} setting max jaw limits'.format(machine_ref))
+                #
+                # Set segment conversion properties
+                mu = 0
+                num_beams = 0
+                for bs in ts.BeamSettings:
+                    mu += bs.ForBeam.BeamMU
+                    num_beams += 1
+                if mu > 0:
+                    logging.warning('This plan may not have typical SMLC optimization params enforced')
+                else:
+                    ts.SegmentConversion.MinSegmentArea = min_segment_area
+                    ts.SegmentConversion.MinSegmentMUPerFraction = min_segment_mu
+                    maximum_segments = num_beams * maximum_segments_per_beam
+                    ts.SegmentConversion.MinNumberOfOpenLeafPairs = min_leaf_pairs
+                    ts.SegmentConversion.MinLeafEndSeparation = min_leaf_end_separation
+                    ts.SegmentConversion.MaxNumberOfSegments = str(maximum_segments)
+                #
+                # Set TrueBeamSTx jaw limits
+                machine_ref = ts.ForTreatmentSetup.MachineReference.MachineName
+                if machine_ref == 'TrueBeamSTx':
+                    logging.info('Current Machine is {} setting max jaw limits'.format(machine_ref))
 
-                        limit = [-20, 20, -10.9, 10.9]
+                    limit = [-20, 20, -10.8, 10.8]
+                    for beams in ts.BeamSettings:
                         # Reference the beamset by the subobject in ForTreatmentSetup
                         success = BeamOperations.check_beam_limits(beams.ForBeam.Name,
                                                                    plan=plan,
@@ -720,28 +817,127 @@ def optimize_plan(patient, case, plan, beamset, **optimization_inputs):
                                                      ' on next attempt at this script')
                             status.finish('Restart required')
                             sys.exit('Restart Required: Select reset beams on next run of script.')
+            elif ts.ForTreatmentSetup.DeliveryTechnique == 'DynamicArc':
+                #
+                # Execute treatment margin settings
+                treat_rois = select_rois_for_treat(plan, beamset=ts.ForTreatmentSetup, rois=None)
+                for beams in ts.BeamSettings:
+                    mu = beams.ForBeam.BeamMU
+                    if mu > 0:
+                        logging.debug('This beamset is already optimized.' +
+                                      ' Not applying treat settings to Beam {}'.format(beams.ForBeam.Name))
+                    else:
+                        set_treat_margins(beam=beams.ForBeam, rois=treat_rois, margins=margins)
+                #
+                # Check the control point spacing on arcs
+                for beams in ts.BeamSettings:
+                    mu = beams.ForBeam.BeamMU
+                    if beams.ArcConversionPropertiesPerBeam is not None:
+                        if beams.ArcConversionPropertiesPerBeam.FinalArcGantrySpacing > 2:
+                            if mu > 0:
+                                # If there are MU then this field has already been optimized with the wrong gantry
+                                # spacing. For shame....
+                                logging.info('This beamset is already optimized with > 2 degrees.  Reset needed')
+                                UserInterface.WarningBox('Restart Required: Attempt to correct final gantry ' +
+                                                         'spacing failed - check reset beams' +
+                                                         ' on next attempt at this script')
+                                status.finish('Restart required')
+                                sys.exit('Restart Required: Select reset beams on next run of script.')
+                            else:
+                                beams.ArcConversionPropertiesPerBeam.EditArcBasedBeamOptimizationSettings(
+                                    FinalGantrySpacing=2)
+                machine_ref = ts.ForTreatmentSetup.MachineReference.MachineName
+                if machine_ref == 'TrueBeamSTx':
+                    logging.info('Current Machine is {} setting max jaw limits'.format(machine_ref))
+                    limit = [-20, 20, -10.8, 10.8]
+                    for beams in ts.BeamSettings:
+                        # Reference the beamset by the subobject in ForTreatmentSetup
+                        success = BeamOperations.check_beam_limits(beams.ForBeam.Name,
+                                                                   plan=plan,
+                                                                   beamset=ts.ForTreatmentSetup,
+                                                                   limit=limit,
+                                                                   change=True,
+                                                                   verbose_logging=True)
+                        if not success:
+                            # If there are MU then this field has already been optimized with the wrong jaw limits
+                            # For Shame....
+                            logging.debug('This beamset is already optimized with unconstrained jaws. Reset needed')
+                            UserInterface.WarningBox('Restart Required: Attempt to limit TrueBeamSTx ' +
+                                                     'jaws failed - check reset beams' +
+                                                     ' on next attempt at this script')
+                            status.finish('Restart required')
+                            sys.exit('Restart Required: Select reset beams on next run of script.')
+                # for beams in ts.BeamSettings:
+                #     mu = beams.ForBeam.BeamMU
+                #
+                #     if beams.TomoPropertiesPerBeam is not None:
+                #     elif beams.ForBeam.DeliveryTechnique == 'SMLC':
+                #         if mu > 0:
+                #             logging.debug('This beamset is already optimized with beamsplitting not applied')
+                #             logging.debug('This beamset is already optimized. Not applying treat settings to targets')
+                #         else:
+                #             beams.AllowBeamSplit = allow_beam_split
+                #             set_treat_margins(beam=beams.ForBeam, rois=treat_rois, margins=margins)
+                #     elif beams.ArcConversionPropertiesPerBeam is not None:
+                #         # Set the control point spacing for Arc Beams
+                #         if mu > 0:
+                #             logging.debug('This beamset is already optimized. Not applying treat settings to targets')
+                #         else:
+                #             set_treat_margins(beam=beams.ForBeam, rois=treat_rois, margins=margins)
+                #         if beams.ArcConversionPropertiesPerBeam.FinalArcGantrySpacing > 2:
+                #             if mu > 0:
+                #                 # If there are MU then this field has already been optimized with the wrong gantry
+                #                 # spacing. For shame....
+                #                 logging.info('This beamset is already optimized with > 2 degrees.  Reset needed')
+                #                 UserInterface.WarningBox('Restart Required: Attempt to correct final gantry ' +
+                #                                          'spacing failed - check reset beams' +
+                #                                          ' on next attempt at this script')
+                #                 status.finish('Restart required')
+                #                 sys.exit('Restart Required: Select reset beams on next run of script.')
+                #             else:
+                #                 beams.ArcConversionPropertiesPerBeam.EditArcBasedBeamOptimizationSettings(
+                #                     FinalGantrySpacing=2)
+                #         # Maximum Jaw Sizes should be limited for STx beams
+                #         # Determine the current machine
+                #     machine_ref = ts.ForTreatmentSetup.MachineReference.MachineName
+                #     if machine_ref == 'TrueBeamSTx':
+                #         logging.info('Current Machine is {} setting max jaw limits'.format(machine_ref))
+                #
+                #         limit = [-20, 20, -10.8, 10.8]
+                #         # Reference the beamset by the subobject in ForTreatmentSetup
+                #         success = BeamOperations.check_beam_limits(beams.ForBeam.Name,
+                #                                                    plan=plan,
+                #                                                    beamset=ts.ForTreatmentSetup,
+                #                                                    limit=limit,
+                #                                                    change=True,
+                #                                                    verbose_logging=True)
+                #         if not success:
+                #             # If there are MU then this field has already been optimized with the wrong jaw limits
+                #             # For Shame....
+                #             logging.debug('This beamset is already optimized with unconstrained jaws. Reset needed')
+                #             UserInterface.WarningBox('Restart Required: Attempt to limit TrueBeamSTx ' +
+                #                                      'jaws failed - check reset beams' +
+                #                                      ' on next attempt at this script')
+                #             status.finish('Restart required')
+                #             sys.exit('Restart Required: Select reset beams on next run of script.')
 
-                num_beams += 1
-            if ts.ForTreatmentSetup.DeliveryTechnique == 'SMLC':
-                if mu > 0:
-                    logging.warning('This plan may not have typical SMLC optimization params enforced')
-                else:
-                    ts.SegmentConversion.MinSegmentArea = min_segment_area
-                    ts.SegmentConversion.MinSegmentMUPerFraction = min_segment_mu
-                    maximum_segments = num_beams * maximum_segments_per_beam
-                    ts.SegmentConversion.MinNumberOfOpenLeafPairs = min_leaf_pairs
-                    ts.SegmentConversion.MinLeafEndSeparation = min_leaf_end_separation
-                    ts.SegmentConversion.MaxNumberOfSegments = str(maximum_segments)
+                # num_beams += 1
+            # if ts.ForTreatmentSetup.DeliveryTechnique == 'SMLC':
+            #     if mu > 0:
+            #         logging.warning('This plan may not have typical SMLC optimization params enforced')
+            #     else:
+            #         ts.SegmentConversion.MinSegmentArea = min_segment_area
+            #         ts.SegmentConversion.MinSegmentMUPerFraction = min_segment_mu
+            #         maximum_segments = num_beams * maximum_segments_per_beam
+            #         ts.SegmentConversion.MinNumberOfOpenLeafPairs = min_leaf_pairs
+            #         ts.SegmentConversion.MinLeafEndSeparation = min_leaf_end_separation
+            #         ts.SegmentConversion.MaxNumberOfSegments = str(maximum_segments)
 
         while Optimization_Iteration != maximum_iteration:
-            # Small target
-            # Check for small targets by evaluating the jaw size
-            # Record the previous total objective function value
             if plan_optimization.Objective.FunctionValue is None:
                 previous_objective_function = 0
             else:
                 previous_objective_function = plan_optimization.Objective.FunctionValue.FunctionValue
-
             # If the change_dose_grid list has a non-zero element change the dose grid
             if vary_grid:
                 if change_dose_grid[Optimization_Iteration] != 0:
@@ -763,45 +959,14 @@ def optimize_plan(patient, case, plan, beamset, **optimization_inputs):
                     report_inputs.setdefault('time_dose_grid_final', []).append(datetime.datetime.now())
             # Start the clock
             report_inputs.setdefault('time_iteration_initial', []).append(datetime.datetime.now())
-            # We are now using JawSet-Backs, not need for small-target evaluation
-            # Small target
-            # if small_target:
-            #    if Optimization_Iteration == 0:
-            #        plan_optimization_parameters.Algorithm.MaxNumberOfIterations = initial_maximum_iteration
-            #        plan_optimization_parameters.DoseCalculation.IterationsInPreparationsPhase = \
-            #            initial_intermediate_iteration
-            #        status.next_step(
-            #            text='Running test iteration for small target size')
-            #        plan.PlanOptimizations[OptIndex].RunOptimization()
-            #        plan.PlanOptimizations[OptIndex].RunOptimization()
-            #        restart = check_min_jaws(plan_optimization, min_dim)
-            #        if restart:
-            #            Optimization_Iteration = 0
-            #        else:
-            #            Optimization_Iteration = 1
-            #            status.next_step('Iteration 1 completed during small target test - advancing')
-            #    else:
-            #        restart = check_min_jaws(plan_optimization, min_dim)
-            #        if restart:
-            #            # Reset the optimization count
-            #            logging.info('Jaw sizes still appear to be smaller than their nomimal minimum')
-            #else:
-            #    restart = check_min_jaws(plan_optimization, min_dim)
-            #    if restart:
-            #        # Stop the calculation, and warn the user to run small target for this case.
-            #        logging.warning("User is running calculation for small target without jaw-locking")
-            #        status.finish('Restart required select small-target')
-            #        sys.exit("Restart the optimization with small-target selected")
             status.next_step(
                 text='Running current iteration = {} of {}'.format(Optimization_Iteration + 1, maximum_iteration))
             logging.info(
                 'Current iteration = {} of {}'.format(Optimization_Iteration + 1, maximum_iteration))
-            #            status.next_step(text='Iterating....')
             # Run the optimization
             plan.PlanOptimizations[OptIndex].RunOptimization()
             # Stop the clock
             report_inputs.setdefault('time_iteration_final', []).append(datetime.datetime.now())
-
             Optimization_Iteration += 1
             logging.info("Optimization Number: {} completed".format(Optimization_Iteration))
             # Set the Maximum iterations and segmentation iteration to a lower number for the initial run
@@ -818,40 +983,51 @@ def optimize_plan(patient, case, plan, beamset, **optimization_inputs):
 
         # Finish with a Reduce OAR Dose Optimization
         if segment_weight:
-            status.next_step('Running Segment weight only optimization')
-            report_inputs['time_segment_weight_initial'] = datetime.datetime.now()
-            # Uncomment when segment-weight based co-optimization is supported
-            if cooptimization:
-                logging.warning("Co-optimized segment weight-based optimization is" +
-                                " not supported by RaySearch at this time.")
-                connect.await_user_input("Segment-weight optimization with composite optimization is not supported " +
-                                         "by RaySearch at this time")
-
+            if beamset.DeliveryTechnique == 'TomoHelical':
+                status.next_step('TomoHelical Plan skipping Segment weight only optimization')
+                logging.warning('Segment weight based optimization is not supported for TomoHelical')
+                report_inputs['time_segment_weight_initial'] = datetime.datetime.now()
+                report_inputs['time_segment_weight_final'] = datetime.datetime.now()
             else:
-                for ts in treatment_setup_settings:
-                    for beams in ts.BeamSettings:
-                        if 'SegmentOpt' in beams.OptimizationTypes:
-                            beams.EditBeamOptimizationSettings(
-                                OptimizationTypes=["SegmentMU"]
-                            )
-                plan.PlanOptimizations[OptIndex].RunOptimization()
-                logging.info('Current total objective function value at iteration {} is {}'.format(
-                    Optimization_Iteration, plan_optimization.Objective.FunctionValue.FunctionValue))
-            report_inputs['time_segment_weight_final'] = datetime.datetime.now()
+                status.next_step('Running Segment weight only optimization')
+                report_inputs['time_segment_weight_initial'] = datetime.datetime.now()
+                # Uncomment when segment-weight based co-optimization is supported
+                if cooptimization:
+                    logging.warning("Co-optimized segment weight-based optimization is" +
+                                    " not supported by RaySearch at this time.")
+                    connect.await_user_input("Segment-weight optimization with composite optimization is not supported " +
+                                             "by RaySearch at this time")
+                else:
+                    for ts in treatment_setup_settings:
+                        for beams in ts.BeamSettings:
+                            if 'SegmentOpt' in beams.OptimizationTypes:
+                                beams.EditBeamOptimizationSettings(
+                                    OptimizationTypes=["SegmentMU"]
+                                )
+                    plan.PlanOptimizations[OptIndex].RunOptimization()
+                    logging.info('Current total objective function value at iteration {} is {}'.format(
+                        Optimization_Iteration, plan_optimization.Objective.FunctionValue.FunctionValue))
+                report_inputs['time_segment_weight_final'] = datetime.datetime.now()
 
         # Finish with a Reduce OAR Dose Optimization
         reduce_oar_success = False
         if reduce_oar:
-            status.next_step('Running ReduceOar Dose')
-            report_inputs['time_reduceoar_initial'] = datetime.datetime.now()
-            reduce_oar_success = reduce_oar_dose(plan_optimization=plan_optimization)
-            report_inputs['time_reduceoar_final'] = datetime.datetime.now()
-            if reduce_oar_success:
-                logging.info('ReduceOAR successfully completed')
+            if beamset.DeliveryTechnique == 'TomoHelical':
+                status.next_step('TomoHelical Plan skipping reduce oar dose optimization')
+                logging.warning('Segment weight based optimization is not supported for TomoHelical')
+                report_inputs['time_reduce_oar_initial'] = datetime.datetime.now()
+                report_inputs['time_reduce_oar_final'] = datetime.datetime.now()
             else:
-                logging.warning('ReduceOAR failed')
-            logging.info('Current total objective function value at iteration {} is {}'.format(
-                Optimization_Iteration, plan_optimization.Objective.FunctionValue))
+                status.next_step('Running ReduceOar Dose')
+                report_inputs['time_reduceoar_initial'] = datetime.datetime.now()
+                reduce_oar_success = reduce_oar_dose(plan_optimization=plan_optimization)
+                report_inputs['time_reduceoar_final'] = datetime.datetime.now()
+                if reduce_oar_success:
+                    logging.info('ReduceOAR successfully completed')
+                else:
+                    logging.warning('ReduceOAR failed')
+                logging.info('Current total objective function value at iteration {} is {}'.format(
+                    Optimization_Iteration, plan_optimization.Objective.FunctionValue))
 
     report_inputs['time_total_final'] = datetime.datetime.now()
     if save_at_complete:
@@ -871,4 +1047,3 @@ def optimize_plan(patient, case, plan, beamset, **optimization_inputs):
 
     status.next_step('Optimization summary')
     status.finish(on_screen_message)
-

--- a/library/PlanQualityAssuranceTests.py
+++ b/library/PlanQualityAssuranceTests.py
@@ -17,13 +17,16 @@
 
     You should have received a copy of the GNU General Public License along with
     this program. If not, see <http://www.gnu.org/licenses/>.
+
+    1.0.0 Updated with multiple tests including cps, gridsize and external overlap
+    1.0.1 Bug fix to handle cases with no External or support structures designated
     """
 
 __author__ = 'Adam Bayliss'
 __contact__ = 'rabayliss@wisc.edu'
 __date__ = '2018-09-05'
 
-__version__ = '1.0.4'
+__version__ = '1.0.1'
 __status__ = 'Production'
 __deprecated__ = False
 __reviewer__ = 'Adam Bayliss'
@@ -124,18 +127,26 @@ def external_overlap_test(patient, case, exam):
     :param patient: RS patient
     :param case: RS case
     :param exam: Rs exam
-    :return: error: string message of any overlap
+    :return: error: string message of any overlap, empty string for No error
     """
+    error = ''
     structure = StructureOperations.find_types(case, 'External')
+    if not structure:
+        logging.exception('There is not structure with type External. Designate an external and re-run script')
+        error = 'No structures with External DICOM type'
+
     supports = StructureOperations.find_types(case, 'Support')
-    overlap_volume = StructureOperations.check_overlap(patient=patient,
+    if supports:
+        overlap_volume = StructureOperations.check_overlap(patient=patient,
                                                        case=case,
                                                        exam=exam,
                                                        structure=structure,
                                                        rois=supports)
-    error = ''
-    if overlap_volume > 1:
-        error += 'Significant overlap exists between {} and {}'.format(structure, supports)
+        if overlap_volume > 1:
+            error += 'Significant overlap exists between {} and {}'.format(structure, supports)
+    else:
+        logging.debug('No support structures exist for evaluation of overlap')
+        error = 'No support structures'
 
     return error
 

--- a/library/StructureOperations.py
+++ b/library/StructureOperations.py
@@ -586,6 +586,7 @@ def check_overlap(patient, case, exam, structure, rois):
         "StructType": "Undefined"}
     make_boolean_structure(patient=patient, case=case, examination=exam,
                                                **overlap_defs)
+    vol = None
     try:
         t = case.PatientModel.StructureSets[exam.Name]. \
             RoiGeometries[overlap_name]

--- a/protocols/UW/UWBrainCNS.xml
+++ b/protocols/UW/UWBrainCNS.xml
@@ -65,8 +65,8 @@
             <roi>
                 <name>PTV_p</name>
                 <type dir="ge">VX</type>
-                <volume units="%">99</volume>
-                <dose units="%" roi="PTV_p">95</dose>
+                <volume units="%">98</volume>
+                <dose units="%" roi="PTV_p">100</dose>
                 <priority>4</priority>
             </roi>
             <roi>

--- a/protocols/UW/UWGeneric.xml
+++ b/protocols/UW/UWGeneric.xml
@@ -346,4 +346,32 @@
             <priority>5</priority>
         </goalset>
     </goals>
+    <beamset>
+        <name>Tomo3D-FW5</name>
+        <technique>TomoHelical</technique>
+        <DicomName>XXXX_THI_R_A_</DicomName>
+        <description>XXXX
+        </description>
+        <beam>
+            <BeamNumber>1</BeamNumber>
+            <DeliveryTechnique>TomoHelical</DeliveryTechnique>
+            <Name>1_SITE_THI</Name>
+            <FieldWidth>5</FieldWidth>
+            <Energy>6</Energy>
+        </beam>
+    </beamset>
+    <beamset>
+        <name>Tomo3D-FW2.5</name>
+        <technique>TomoHelical</technique>
+        <DicomName>XXXX_THI_R_A_</DicomName>
+        <description>XXXX
+        </description>
+        <beam>
+            <BeamNumber>1</BeamNumber>
+            <DeliveryTechnique>TomoHelical</DeliveryTechnique>
+            <Name>1_SITE_THI</Name>
+            <FieldWidth>2.5</FieldWidth>
+            <Energy>6</Energy>
+        </beam>
+    </beamset>
 </protocol>

--- a/protocols/UW/UWGeneric.xml
+++ b/protocols/UW/UWGeneric.xml
@@ -372,6 +372,7 @@
             <Name>1_SITE_THI</Name>
             <FieldWidth>2.5</FieldWidth>
             <Energy>6</Energy>
+            <Pitch>0.287</Pitch>
         </beam>
     </beamset>
 </protocol>

--- a/protocols/UW/UWLungSBRT.xml
+++ b/protocols/UW/UWLungSBRT.xml
@@ -151,7 +151,7 @@
                 <ref>RTOG 0813</ref>
                 <volume units="cc">4</volume>
                 <dose units="Gy">18</dose>
-                <priority>1</priority>
+                <priority>3</priority>
             </roi>
             <roi>
                 <name>Bronchus_L_PRV05</name>
@@ -174,7 +174,7 @@
                 <ref>RTOG 0813</ref>
                 <volume units="cc">4</volume>
                 <dose units="Gy">18</dose>
-                <priority>1</priority>
+                <priority>3</priority>
             </roi>
             <roi>
                 <name>Bronchus_R_PRV05</name>
@@ -373,7 +373,7 @@
                 <ref>RTOG 0813</ref>
                 <volume units="cc">4</volume>
                 <dose units="Gy">18</dose>
-                <priority>1</priority>
+                <priority>3</priority>
             </roi>
             <roi>
                 <name>Trachea</name>
@@ -527,7 +527,7 @@
                 <ref>RTOG 0813</ref>
                 <volume units="cc">4</volume>
                 <dose units="Gy">18</dose>
-                <priority>1</priority>
+                <priority>3</priority>
             </roi>
             <roi>
                 <name>Bronchus_L_PRV05</name>
@@ -550,7 +550,7 @@
                 <ref>RTOG 0813</ref>
                 <volume units="cc">4</volume>
                 <dose units="Gy">18</dose>
-                <priority>1</priority>
+                <priority>3</priority>
             </roi>
             <roi>
                 <name>Bronchus_R_PRV05</name>
@@ -748,7 +748,7 @@
                 <ref>RTOG 0813</ref>
                 <volume units="cc">4</volume>
                 <dose units="Gy">18</dose>
-                <priority>1</priority>
+                <priority>3</priority>
             </roi>
             <roi>
                 <name>Trachea</name>
@@ -1489,7 +1489,7 @@
                 <ref>RTOG 0813 BED a/b=3</ref>
                 <volume units="cc">4</volume>
                 <dose units="Gy">16</dose>
-                <priority>1</priority>
+                <priority>3</priority>
             </roi>
             <roi>
                 <name>Trachea</name>
@@ -1640,7 +1640,7 @@
                 <ref>RTOG 0813 BED a/b=3</ref>
                 <volume units="cc">4</volume>
                 <dose units="Gy">14</dose>
-                <priority>1</priority>
+                <priority>3</priority>
             </roi>
             <roi>
                 <name>Bronchus_L_PRV05</name>
@@ -1663,7 +1663,7 @@
                 <ref>RTOG 0813 BED a/b=3</ref>
                 <volume units="cc">4</volume>
                 <dose units="Gy">14</dose>
-                <priority>1</priority>
+                <priority>3</priority>
             </roi>
             <roi>
                 <name>Bronchus_R_PRV05</name>
@@ -1862,7 +1862,7 @@
                 <ref>RTOG 0813 BED a/b=3</ref>
                 <volume units="cc">4</volume>
                 <dose units="Gy">14</dose>
-                <priority>1</priority>
+                <priority>3</priority>
             </roi>
             <roi>
                 <name>Trachea</name>
@@ -2011,7 +2011,7 @@
                 <ref>RTOG 0813 BED a/b=3</ref>
                 <volume units="cc">4</volume>
                 <dose units="Gy">14</dose>
-                <priority>1</priority>
+                <priority>3</priority>
             </roi>
             <roi>
                 <name>Bronchus_L_PRV05</name>
@@ -2034,7 +2034,7 @@
                 <ref>RTOG 0813 BED a/b=3</ref>
                 <volume units="cc">4</volume>
                 <dose units="Gy">14</dose>
-                <priority>1</priority>
+                <priority>3</priority>
             </roi>
             <roi>
                 <name>Bronchus_R_PRV05</name>
@@ -2233,7 +2233,7 @@
                 <ref>RTOG 0813 BED a/b=3</ref>
                 <volume units="cc">4</volume>
                 <dose units="Gy">14</dose>
-                <priority>1</priority>
+                <priority>3</priority>
             </roi>
             <roi>
                 <name>Trachea</name>

--- a/protocols/UW/UWLungSBRT.xml
+++ b/protocols/UW/UWLungSBRT.xml
@@ -146,14 +146,6 @@
                 <priority>3</priority>
             </roi>
             <roi>
-                <name>Bronchus_L</name>
-                <type>DX</type>
-                <ref>RTOG 0813</ref>
-                <volume units="cc">4</volume>
-                <dose units="Gy">18</dose>
-                <priority>3</priority>
-            </roi>
-            <roi>
                 <name>Bronchus_L_PRV05</name>
                 <type>VX</type>
                 <ref>TPO Update to ICRU Recommendation Nov2018</ref>
@@ -166,14 +158,6 @@
                 <type>DX</type>
                 <volume units="cc">0.1</volume>
                 <dose units="Gy">37</dose>
-                <priority>3</priority>
-            </roi>
-            <roi>
-                <name>Bronchus_R</name>
-                <type>DX</type>
-                <ref>RTOG 0813</ref>
-                <volume units="cc">4</volume>
-                <dose units="Gy">18</dose>
                 <priority>3</priority>
             </roi>
             <roi>
@@ -365,14 +349,6 @@
                 <ref>TPO Update to ICRU Recommendation Nov2018</ref>
                 <volume units="%">2</volume>
                 <dose units="Gy">24</dose>
-                <priority>3</priority>
-            </roi>
-            <roi>
-                <name>Trachea</name>
-                <type>DX</type>
-                <ref>RTOG 0813</ref>
-                <volume units="cc">4</volume>
-                <dose units="Gy">18</dose>
                 <priority>3</priority>
             </roi>
             <roi>
@@ -522,14 +498,6 @@
                 <priority>3</priority>
             </roi>
             <roi>
-                <name>Bronchus_L</name>
-                <type>DX</type>
-                <ref>RTOG 0813</ref>
-                <volume units="cc">4</volume>
-                <dose units="Gy">18</dose>
-                <priority>3</priority>
-            </roi>
-            <roi>
                 <name>Bronchus_L_PRV05</name>
                 <type>VX</type>
                 <ref>TPO Update to ICRU Recommendation Nov2018</ref>
@@ -542,14 +510,6 @@
                 <type>DX</type>
                 <volume units="cc">0.1</volume>
                 <dose units="Gy">37</dose>
-                <priority>3</priority>
-            </roi>
-            <roi>
-                <name>Bronchus_R</name>
-                <type>DX</type>
-                <ref>RTOG 0813</ref>
-                <volume units="cc">4</volume>
-                <dose units="Gy">18</dose>
                 <priority>3</priority>
             </roi>
             <roi>
@@ -745,14 +705,6 @@
             <roi>
                 <name>Trachea</name>
                 <type>DX</type>
-                <ref>RTOG 0813</ref>
-                <volume units="cc">4</volume>
-                <dose units="Gy">18</dose>
-                <priority>3</priority>
-            </roi>
-            <roi>
-                <name>Trachea</name>
-                <type>DX</type>
                 <volume units="cc">0.1</volume>
                 <dose units="Gy">37</dose>
                 <priority>3</priority>
@@ -894,13 +846,6 @@
                 <priority>3</priority>
             </roi>
             <roi>
-                <name>Bronchus_L</name>
-                <type>DX</type>
-                <volume units="cc">4</volume>
-                <dose units="Gy">16</dose>
-                <priority>1</priority>
-            </roi>
-            <roi>
                 <name>Bronchus_L_PRV05</name>
                 <type>VX</type>
                 <ref>TPO Update to ICRU Recommendation Nov2018</ref>
@@ -914,13 +859,6 @@
                 <volume units="cc">0.1</volume>
                 <dose units="Gy">34</dose>
                 <priority>3</priority>
-            </roi>
-            <roi>
-                <name>Bronchus_R</name>
-                <type>DX</type>
-                <volume units="cc">4</volume>
-                <dose units="Gy">16</dose>
-                <priority>1</priority>
             </roi>
             <roi>
                 <name>Bronchus_R_PRV05</name>
@@ -1112,13 +1050,6 @@
                 <volume units="%">2</volume>
                 <dose units="Gy">22</dose>
                 <priority>3</priority>
-            </roi>
-            <roi>
-                <name>Trachea</name>
-                <type>DX</type>
-                <volume units="cc">4</volume>
-                <dose units="Gy">16</dose>
-                <priority>1</priority>
             </roi>
             <roi>
                 <name>Trachea</name>
@@ -1264,13 +1195,6 @@
                 <priority>3</priority>
             </roi>
             <roi>
-                <name>Bronchus_L</name>
-                <type>DX</type>
-                <volume units="cc">4</volume>
-                <dose units="Gy">16</dose>
-                <priority>1</priority>
-            </roi>
-            <roi>
                 <name>Bronchus_L_PRV05</name>
                 <type>VX</type>
                 <ref>TPO Update to ICRU Recommendation Nov2018</ref>
@@ -1284,13 +1208,6 @@
                 <volume units="cc">0.1</volume>
                 <dose units="Gy">34</dose>
                 <priority>3</priority>
-            </roi>
-            <roi>
-                <name>Bronchus_R</name>
-                <type>DX</type>
-                <volume units="cc">4</volume>
-                <dose units="Gy">16</dose>
-                <priority>1</priority>
             </roi>
             <roi>
                 <name>Bronchus_R_PRV05</name>
@@ -1481,14 +1398,6 @@
                 <ref>TPO Update to ICRU Recommendation Nov2018</ref>
                 <volume units="%">2</volume>
                 <dose units="Gy">22</dose>
-                <priority>3</priority>
-            </roi>
-            <roi>
-                <name>Trachea</name>
-                <type>DX</type>
-                <ref>RTOG 0813 BED a/b=3</ref>
-                <volume units="cc">4</volume>
-                <dose units="Gy">16</dose>
                 <priority>3</priority>
             </roi>
             <roi>
@@ -1635,14 +1544,6 @@
                 <priority>3</priority>
             </roi>
             <roi>
-                <name>Bronchus_L</name>
-                <type>DX</type>
-                <ref>RTOG 0813 BED a/b=3</ref>
-                <volume units="cc">4</volume>
-                <dose units="Gy">14</dose>
-                <priority>3</priority>
-            </roi>
-            <roi>
                 <name>Bronchus_L_PRV05</name>
                 <type>VX</type>
                 <ref>TPO Update to ICRU Recommendation Nov2018</ref>
@@ -1655,14 +1556,6 @@
                 <type>DX</type>
                 <volume units="cc">0.1</volume>
                 <dose units="Gy">30</dose>
-                <priority>3</priority>
-            </roi>
-            <roi>
-                <name>Bronchus_R</name>
-                <type>DX</type>
-                <ref>RTOG 0813 BED a/b=3</ref>
-                <volume units="cc">4</volume>
-                <dose units="Gy">14</dose>
                 <priority>3</priority>
             </roi>
             <roi>
@@ -1859,14 +1752,6 @@
             <roi>
                 <name>Trachea</name>
                 <type>DX</type>
-                <ref>RTOG 0813 BED a/b=3</ref>
-                <volume units="cc">4</volume>
-                <dose units="Gy">14</dose>
-                <priority>3</priority>
-            </roi>
-            <roi>
-                <name>Trachea</name>
-                <type>DX</type>
                 <volume units="cc">0.1</volume>
                 <dose units="Gy">30</dose>
                 <priority>3</priority>
@@ -2006,14 +1891,6 @@
                 <priority>3</priority>
             </roi>
             <roi>
-                <name>Bronchus_L</name>
-                <type>DX</type>
-                <ref>RTOG 0813 BED a/b=3</ref>
-                <volume units="cc">4</volume>
-                <dose units="Gy">14</dose>
-                <priority>3</priority>
-            </roi>
-            <roi>
                 <name>Bronchus_L_PRV05</name>
                 <type>VX</type>
                 <ref>TPO Update to ICRU Recommendation Nov2018</ref>
@@ -2026,14 +1903,6 @@
                 <type>DX</type>
                 <volume units="cc">0.1</volume>
                 <dose units="Gy">30</dose>
-                <priority>3</priority>
-            </roi>
-            <roi>
-                <name>Bronchus_R</name>
-                <type>DX</type>
-                <ref>RTOG 0813 BED a/b=3</ref>
-                <volume units="cc">4</volume>
-                <dose units="Gy">14</dose>
                 <priority>3</priority>
             </roi>
             <roi>
@@ -2225,14 +2094,6 @@
                 <ref>TPO Update to ICRU Recommendation Nov2018</ref>
                 <volume units="%">2</volume>
                 <dose units="Gy">18</dose>
-                <priority>3</priority>
-            </roi>
-            <roi>
-                <name>Trachea</name>
-                <type>DX</type>
-                <ref>RTOG 0813 BED a/b=3</ref>
-                <volume units="cc">4</volume>
-                <dose units="Gy">14</dose>
                 <priority>3</priority>
             </roi>
             <roi>
@@ -2385,14 +2246,6 @@
                 <priority>3</priority>
             </roi>
             <roi>
-                <name>Bronchus_L</name>
-                <type>DX</type>
-                <ref>RTOG 0813</ref>
-                <volume units="cc">4</volume>
-                <dose units="Gy">20</dose>
-                <priority>3</priority>
-            </roi>
-            <roi>
                 <name>Bronchus_L_PRV05</name>
                 <type>VX</type>
                 <ref>TPO Update to ICRU Recommendation Nov2018</ref>
@@ -2412,14 +2265,6 @@
                 <type>DX</type>
                 <volume units="cc">0.1</volume>
                 <dose units="Gy">44</dose>
-                <priority>3</priority>
-            </roi>
-            <roi>
-                <name>Bronchus_R</name>
-                <type>DX</type>
-                <ref>RTOG 0813</ref>
-                <volume units="cc">4</volume>
-                <dose units="Gy">20</dose>
                 <priority>3</priority>
             </roi>
             <roi>
@@ -2695,14 +2540,6 @@
                 <type>DX</type>
                 <volume units="cc">0.1</volume>
                 <dose units="Gy">44</dose>
-                <priority>3</priority>
-            </roi>
-            <roi>
-                <name>Trachea</name>
-                <type>DX</type>
-                <ref>RTOG 0813</ref>
-                <volume units="cc">4</volume>
-                <dose units="Gy">20</dose>
                 <priority>3</priority>
             </roi>
             <roi>

--- a/protocols/UW/beamsets/UWVMAT_Beamsets.xml
+++ b/protocols/UW/beamsets/UWVMAT_Beamsets.xml
@@ -1168,6 +1168,22 @@
         </beamset>
     </beam_template>
     <beam_template>
+        <name>TomoHelical</name>
+        <beamset>
+            <name>TomoHelical3D</name>
+            <technique>TomoHelical</technique>
+            <DicomName>XXXX_THI_R_A_</DicomName>
+            <description>XXXX
+            </description>
+            <beam>
+                <BeamNumber>1</BeamNumber>
+                <DeliveryTechnique>TomoHelical</DeliveryTechnique>
+                <Name>1_SITE_THI</Name>
+                <Energy>6</Energy>
+            </beam>
+        </beamset>
+    </beam_template>
+    <beam_template>
         <name>Blank Template</name>
         <beamset>
             <name>VMAT TemplateName</name>

--- a/testing/test_log_parse.py
+++ b/testing/test_log_parse.py
@@ -71,8 +71,9 @@ def main():
             logging.info('Grid size was changed for Normal-type plan')
 
     important = []
-    keep_phrases = ["CRITICAL", "WARNING"]
-    log_dir = r"\\uwhis.hosp.wisc.edu\ufs\UWHealth\RadOnc\ShareAll\RayScripts\logs"
+#    keep_phrases = ["CRITICAL", "WARNING"]
+    keep_phrases = ["CRITICAL"]
+    log_dir = r"Q:\\RadOnc\RayStation\RayScripts\logs"
     log_file = patient.PatientID + '.txt'
     infile = os.path.join(log_dir, patient.PatientID, log_file)
 


### PR DESCRIPTION
UpdateScripts.py:
-There is an incompatibility with the rmtree command and our citrix environment for mapped drives. I have created a "move" of the active directory prior to using rmtree on the master directory and this seems to solve the problem.
-Additionally, due to windows quirkiness a "sleep" is added to the remove operation and the rm is placed in a while to ensure an empty directory prior to updating scripts.

FinalDose.py:
-A number of checks were turned off for debugging prior to submitting them to the master branch on the last commit. The FinalDose script now checks for fiducialpoint location, and overlap with external and support structures.
-Jaw Offsets:
     * Script now sets jaw positions based on the MLC that is farthest from the central axis within the beam. The Eclipse settings are used. The X jaws are set 8 mm from the last open MLC (using the ciao to compute), the y jaws are placed 2 mm from the first and last open MLC's. For dynamic MLC plans the all control points are evaluated for the maximum values.
     * Wide Field behavior: In the event that a jaw move would violate machine limits on MLC positions (max leaf out of carriage), the jaws are positions are tested. If they can be rounded to the nearest mm open without violating the carriage limit then that is done. If they cannot be rounded open without violating a carriage limit, then the jaws are rounded closed to the nearest mm.
-Better error handling was implemented on "Dose-already computed" states of the plan.

StructureOperations.py
-I have put in error handling for a zero volume contour (empty) on an overlap check.

BeamOperations.py:
-MLC properties class:
     * Created a new class called mlc properties that stores the ciao and maximum leaf from carriage positions.
    * Loaded properties of the specific machine in use from the machineDB directly to extend the script capabilities to all machines and avoid STx-specific limits.
    * Put flags in to detect an MLC-retracted state (which in RS still has MLC positions (they are just all at -20 and +20
    *Combined the treatmentsetupsetting search and beam search into a single loop
    * Found a bug in the RayStation API __init__ method for VMAT beams. The UpperLayer from Physics.MlcPhysics is undefined. Pulling the data directly from the machine_dB via a match.
-Added error handling for the dose specification point when the dose is less than the rx (user warned)
-Debug of check existing limits on stx to perform the check even if
the optimization has already started


OptimizationOperations.py
-eliminated small target evaluation (to be handled with jaw setback in final dose)
-Added patient save to the end of the optimize plan to avoid time-out on RS servers causing a loss of saved work.
-Added the automatic setting of treatment margins on VMAT and SMLC
plans to prevent the overexposure of normal tissues inadequately
optimized. This will force the aperture to not be never be larger
than a specified margin around any target roi which exists in the
Objectives list
-Extended this function to co-optimized beamsets to identify the
target being treated by a beamset
-Cleaned up the optimize_plan function in preparation for parameterizing
it using an input file.

UWLungSBRT:
-Eliminating RTOFG 0618 limits on Trachea/Bronchus per MD.

AutomatedWholeBrain.py
-Updated the location of the UWSupport template to autoload the HN portrait board.

Tomo3D:
-A misnomer, I know. Testing preliminary feasibility. Added a beamset template for tomo3d


